### PR TITLE
Refine Add Transaction Modal & Improve UX Flow

### DIFF
--- a/src/budgettracker/BudgetLimits.jsx
+++ b/src/budgettracker/BudgetLimits.jsx
@@ -49,9 +49,9 @@ const BudgetLimits = () => {
 
   // Add frequency options
   const frequencies = [
-    { value: "weekly", label: t("budgets.frequency.weekly") },
-    { value: "monthly", label: t("budgets.frequency.monthly") },
-    { value: "yearly", label: t("budgets.frequency.yearly") },
+    { value: "weekly", label: "Weekly" }, // Replace with plain strings
+    { value: "monthly", label: "Monthly" },
+    { value: "yearly", label: "Yearly" },
   ];
 
   // Calculate next reset date based on frequency
@@ -868,7 +868,7 @@ const BudgetLimits = () => {
 
           <Form.Item
             name="frequency"
-            label={t("budgets.frequency")}
+            label={t("budgets.setBudgetFrequency")} // Use translation key for the label
             rules={[
               { required: true, message: t("budgets.frequencyRequired") },
             ]}
@@ -877,7 +877,7 @@ const BudgetLimits = () => {
             <Select>
               {frequencies.map((freq) => (
                 <Option key={freq.value} value={freq.value}>
-                  {freq.label}
+                  {freq.label} {/* Use the label directly */}
                 </Option>
               ))}
             </Select>
@@ -896,7 +896,12 @@ const BudgetLimits = () => {
               },
             ]}
           >
-            <Input type="number" prefix="$" step="0.01" />
+            <Input
+              type="number"
+              prefix="$"
+              step="0.01"
+              className="dark:bg-gray-700 dark:text-white dark:border-gray-600" // Added dark mode styles
+            />
           </Form.Item>
 
           <div className="flex justify-end gap-2">

--- a/src/budgettracker/Incomesources.jsx
+++ b/src/budgettracker/Incomesources.jsx
@@ -115,6 +115,12 @@ const IncomeSources = () => {
   return (
     <motion.div variants={containerVariants} initial="hidden" animate="visible" className="space-y-6 p-4">
       <motion.div variants={itemVariants} className="bg-white dark:bg-gray-800 p-4 sm:p-6 rounded-xl shadow-sm mb-6">
+        <p className="text-blue-700 dark:text-blue-300 text-sm mb-4">
+          {t(
+            "incomesources.cardManagementNotice",
+            "Currently, this app supports managing only one card (credit or debit) at a time. If you want to track both, you can manage them as a single card by combining their balances. We are actively working on adding support for multiple cards in future updates."
+          )}
+        </p>
         <h1 className="text-xl sm:text-2xl font-semibold text-gray-800 dark:text-white mb-2">
           {t("incomesources.title")}
         </h1>

--- a/src/budgettracker/dashboard.jsx
+++ b/src/budgettracker/dashboard.jsx
@@ -443,6 +443,15 @@ function DashBoard() {
     )
   }
 
+  // Sort savings goals by percentage completed in descending order
+  const sortedSavingsGoals = savingsGoals
+    .filter((goal) => goal.currentAmount < goal.goalAmount)
+    .sort((a, b) => (b.currentAmount / b.goalAmount) - (a.currentAmount / a.goalAmount))
+    .slice(0, 3); // Take the top 3 goals
+
+  // Take the last 3 recent transactions
+  const recentTransactions = financialData.recentTransactions.slice(0, 3);
+
   return (
     <motion.div
       variants={containerVariants}
@@ -594,54 +603,6 @@ function DashBoard() {
               <IncomeExpenseDoughnutChart userId={user?.uid} />
             </div>
           </div>
-
-          {/* Expense Breakdown */}
-          {financialData.totalExpenses > 0 && (
-            <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
-              <h4 className="text-sm font-medium text-gray-600 dark:text-gray-400 mb-6">
-                {t("dashboard.expenseBreakdown")}
-              </h4>
-              <div className="flex flex-col gap-6">
-                <div>
-                  <div className="flex justify-between text-xs mb-3">
-                    <span className="text-gray-500 dark:text-gray-400">
-                      {t("transactions.categories.essential.title")}
-                    </span>
-                    <span className="font-medium text-gray-700 dark:text-gray-300">
-                      ${financialData.essentialExpenses.toLocaleString()}
-                    </span>
-                  </div>
-                  <div className="w-full h-1 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
-                    <div
-                      className="h-full bg-blue-500 rounded-full"
-                      style={{
-                        width: `${(financialData.essentialExpenses / financialData.totalExpenses) * 100}%`,
-                      }}
-                    ></div>
-                  </div>
-                </div>
-
-                <div>
-                  <div className="flex justify-between text-xs mb-3">
-                    <span className="text-gray-500 dark:text-gray-400">
-                      {t("transactions.categories.lifestyle.title")}
-                    </span>
-                    <span className="font-medium text-gray-700 dark:text-gray-300">
-                      ${financialData.lifestyleExpenses.toLocaleString()}
-                    </span>
-                  </div>
-                  <div className="w-full h-1 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
-                    <div
-                      className="h-full bg-purple-500 rounded-full"
-                      style={{
-                        width: `${(financialData.lifestyleExpenses / financialData.totalExpenses) * 100}%`,
-                      }}
-                    ></div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
         </div>
 
         {/* Recent Transactions */}
@@ -651,8 +612,8 @@ function DashBoard() {
             {t("dashboard.recentTransactions")}
           </h3>
           <div className="space-y-4 max-h-[320px] overflow-y-auto pr-2 scrollbar-thin">
-            {financialData.recentTransactions.length > 0 ? (
-              financialData.recentTransactions.map((transaction) => (
+            {recentTransactions.length > 0 ? (
+              recentTransactions.map((transaction) => (
                 <div
                   key={transaction.id}
                   className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-700/50 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors border border-gray-200 dark:border-gray-700"
@@ -711,7 +672,7 @@ function DashBoard() {
             onClick={() => navigate("/transactions")}
             className="w-full mt-6 py-3 text-blue-600 dark:text-finance-blue-400 border border-blue-100 dark:border-finance-blue-800 rounded-xl hover:bg-blue-50 dark:hover:bg-finance-blue-900/20 transition-colors text-sm font-medium"
           >
-            Show All Transactions
+            {t("dashboard.buttons.showAllTransactions")}
           </button>
         </div>
       </motion.div>
@@ -760,36 +721,33 @@ function DashBoard() {
             {t("savingsGoals.title")}
           </h3>
           <div className="space-y-5">
-            {savingsGoals?.filter((goal) => goal.currentAmount < goal.goalAmount).length > 0 ? (
-              savingsGoals
-                ?.filter((goal) => goal.currentAmount < goal.goalAmount)
-                .slice(0, 3)
-                .map((goal) => (
-                  <div key={goal.id} className="space-y-3">
-                    <div className="flex justify-between text-sm">
-                      <Tooltip title={goal.goalName}>
-                        <span className="text-gray-700 dark:text-gray-300 truncate max-w-[200px] font-medium">
-                          {goal.goalName}
-                        </span>
-                      </Tooltip>
-                      <span className="text-gray-600 dark:text-gray-400 whitespace-nowrap text-xs">
-                        ${goal.currentAmount.toLocaleString()} / ${goal.goalAmount.toLocaleString()}
+            {sortedSavingsGoals.length > 0 ? (
+              sortedSavingsGoals.map((goal) => (
+                <div key={goal.id} className="space-y-3">
+                  <div className="flex justify-between text-sm">
+                    <Tooltip title={goal.goalName}>
+                      <span className="text-gray-700 dark:text-gray-300 truncate max-w-[200px] font-medium">
+                        {goal.goalName}
                       </span>
-                    </div>
-                    <Progress
-                      percent={Math.round((goal.currentAmount / goal.goalAmount) * 100)}
-                      strokeColor="#0c8de0"
-                      size="small"
-                      showInfo={false}
-                      strokeWidth={3}
-                    />
-                    <div className="flex justify-end">
-                      <span className="text-xs text-gray-500 dark:text-gray-400">
-                        {Math.round((goal.currentAmount / goal.goalAmount) * 100)}% of your goal achieved
-                      </span>
-                    </div>
+                    </Tooltip>
+                    <span className="text-gray-600 dark:text-gray-400 whitespace-nowrap text-xs">
+                      ${goal.currentAmount.toLocaleString()} / ${goal.goalAmount.toLocaleString()}
+                    </span>
                   </div>
-                ))
+                  <Progress
+                    percent={Math.round((goal.currentAmount / goal.goalAmount) * 100)}
+                    strokeColor="#0c8de0"
+                    size="small"
+                    showInfo={false}
+                    strokeWidth={3}
+                  />
+                  <div className="flex justify-end">
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      {Math.round((goal.currentAmount / goal.goalAmount) * 100)}% of your goal achieved
+                    </span>
+                  </div>
+                </div>
+              ))
             ) : (
               <div className="text-center py-8 bg-gray-50 dark:bg-gray-700/50 rounded-xl border border-gray-200 dark:border-gray-700">
                 <FaInfoCircle className="mx-auto text-gray-400 text-xl mb-2" />
@@ -801,7 +759,7 @@ function DashBoard() {
               onClick={() => navigate("/savings-goals")}
               className="mt-4 w-full py-3 bg-transparent border border-finance-blue-100 dark:border-finance-blue-800 text-finance-blue-600 dark:text-finance-blue-400 rounded-xl hover:bg-finance-blue-50 dark:hover:bg-finance-blue-900/20 transition-all duration-200 text-sm font-medium"
             >
-              {savingsGoals.length > 0 ? "Manage Savings Goals" : "Add a savings goal"}
+              {t("dashboard.buttons.manageSavingsGoals")}
             </button>
           </div>
         </div>

--- a/src/budgettracker/modals/AddTransactionModal.jsx
+++ b/src/budgettracker/modals/AddTransactionModal.jsx
@@ -17,6 +17,7 @@ const AddTransactionModal = ({ open, onClose, onAddTransaction, cardBalance, wal
   const [form] = Form.useForm()
   const [selectedType, setSelectedType] = useState("Income")
   const [error, setError] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false) // Add a state for submission status
 
   // Add check for payment methods
   useEffect(() => {
@@ -196,10 +197,18 @@ const AddTransactionModal = ({ open, onClose, onAddTransaction, cardBalance, wal
     }
   }
 
+  const handleTypeChange = (value) => {
+    setSelectedType(value)
+    // Automatically set the category based on the selected type
+    const defaultCategory = value === "Income" ? "salary" : "rent/mortgage"
+    form.setFieldsValue({ category: defaultCategory })
+  }
+
   // Handle form submission
   const handleSubmit = async (values) => {
     try {
       setError("")
+      setIsSubmitting(true) // Set submitting state to true
       const { type, category, amount, provider, paymentMethod, date } = values
 
       // Validation for payment method balances
@@ -211,6 +220,7 @@ const AddTransactionModal = ({ open, onClose, onAddTransaction, cardBalance, wal
               method: paymentMethod.toLowerCase(),
             })
           )
+          setIsSubmitting(false) // Reset submitting state
           return
         }
       }
@@ -233,6 +243,8 @@ const AddTransactionModal = ({ open, onClose, onAddTransaction, cardBalance, wal
     } catch (error) {
       console.error("Error adding transaction:", error)
       setError(t("transactions.error.addingTransactionMessage"))
+    } finally {
+      setIsSubmitting(false) // Reset submitting state
     }
   }
 
@@ -345,7 +357,7 @@ const AddTransactionModal = ({ open, onClose, onAddTransaction, cardBalance, wal
             >
               <Select
                 className="w-full h-12 text-lg"
-                onChange={(value) => setSelectedType(value)}
+                onChange={handleTypeChange} // Use the updated handler
                 dropdownClassName="dark:bg-gray-800 dark:text-white"
               >
                 <Option value="Income" className="text-lg">
@@ -455,7 +467,7 @@ const AddTransactionModal = ({ open, onClose, onAddTransaction, cardBalance, wal
               <Input
                 prefix="$"
                 placeholder={t("modals.addTransaction.amountPlaceholder")}
-                className="w-full h-12 text-lg px-4 dark:bg-gray-700 dark:text-white dark:border-gray-600"
+                className="w-full h-12 text-lg px-4 dark:bg-gray-700 dark:text-white dark:border-gray-600" // Added dark mode styles
               />
             </Form.Item>
           </div>
@@ -476,7 +488,10 @@ const AddTransactionModal = ({ open, onClose, onAddTransaction, cardBalance, wal
             </button>
             <button
               type="submit"
-              className="px-6 py-2 rounded-lg bg-finance-blue-600 text-white hover:bg-finance-blue-700 transition-colors duration-200 text-lg"
+              className={`px-6 py-2 rounded-lg bg-finance-blue-600 text-white hover:bg-finance-blue-700 transition-colors duration-200 text-lg ${
+                isSubmitting ? "opacity-50 cursor-not-allowed" : ""
+              }`}
+              disabled={isSubmitting} // Disable button while submitting
             >
               {t("modals.addTransaction.save")}
             </button>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -215,7 +215,10 @@ const Sidebar = ({ isOpen, onMenuClick }) => {
               isCollapsed && !isMobile ? "hidden" : ""
             }`}
           >
-            <div className="bg-gradient-to-r from-finance-blue-50 to-finance-blue-100 dark:from-finance-blue-800 dark:to-finance-blue-900 p-3 rounded-lg shadow-md">
+            <div
+              className="bg-gradient-to-r from-finance-blue-50 to-finance-blue-100 dark:from-finance-blue-800 dark:to-finance-blue-900 p-3 rounded-lg shadow-md cursor-pointer"
+              onClick={() => navigate("/settings#help-support")} // Redirect to Help & Support section
+            >
               <h3 className="text-sm font-medium text-finance-blue-700 dark:text-white mb-1">
                 Need Help?
               </h3>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -40,7 +40,11 @@
     },
     "noRecentTransactions": "No recent transactions",
     "noActiveGoals": "No active savings goals",
-    "recentTransactions": "Recent Transactions"
+    "recentTransactions": "Recent Transactions",
+    "buttons": {
+      "showAllTransactions": "Show All Transactions",
+      "manageSavingsGoals": "Manage Savings Goals"
+    }
   },
   "transactions": {
     "title": "Transactions",
@@ -541,6 +545,7 @@
       "danger": "Over budget",
       "warning": "Near limit",
       "good": "Within budget"
-    }
+    },
+    "setBudgetFrequency": "Set Budget Frequency"
   }
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -40,6 +40,10 @@
       "noActiveGoals": "No hay objetivos de ahorro activos",
       "recentTransactions": "Transacciones Recientes",
       "setBudgetLimits": "💡 Establece límites de presupuesto para un mejor control de tus gastos"
+    },
+    "buttons": {
+      "showAllTransactions": "Mostrar todas las transacciones",
+      "manageSavingsGoals": "Gestionar metas de ahorro"
     }
   },
   "transactions": {
@@ -583,6 +587,7 @@
       "message": "¿Estás seguro de que deseas eliminar este límite de presupuesto?",
       "success": "Límite de presupuesto eliminado exitosamente",
       "error": "Error al eliminar el límite de presupuesto"
-    }
+    },
+    "setBudgetFrequency": "Establecer Frecuencia de Presupuesto"
   }
 }


### PR DESCRIPTION
- Updated Add Transaction modal to accept entries with either Income or Expense (no longer both required)
- Removed the Expense Breakdown section
- Fixed translation errors across the interface
- Made the "Need Help?" prompt redirect users to the Help & Support tab